### PR TITLE
blanklines with whitespaces were causing problems in unix

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -5,7 +5,7 @@ local ll = require("iron.lowlevel")
 local focus = require("iron.visibility").focus
 local config = require("iron.config")
 local marks = require("iron.marks")
-local isWindows = require("iron.util.os").isWindows
+local is_windows = require("iron.util.os").is_windows
 
 local autocmds = {}
 
@@ -245,7 +245,7 @@ end
 -- is here to ensure that sending of string.char(13) sends after the commands
 -- are finished sending to the ipython REPL
 core.send = function(ft, data)
-  if not isWindows() then
+  if not is_windows() then
     send(ft, data)
 
   else

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -250,7 +250,7 @@ core.send = function(ft, data)
 
   else
     send(ft, data)
-    
+
     -- This is a hack fix that allows windows ipython to run the commands sent
     -- to the repl. However, the same issue will arise as before (the command sent
     -- to the repl but the code not running) if many lines are sent to the ipython

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -22,12 +22,20 @@ end
 
 
 ---@param lines table
---- Removes empty lines, which includes lines only with whitespaces
+-- Removes empty lines. On unix this includes lines only with 
+-- whitespaces. For some reason, unix needs the white space lines 
+-- removed but windows needs them. Need to figure out why later.
 local function remove_empty_lines(lines)
   local newlines = {}
   for _, line in pairs(lines) do
-    if string.len(line) > 0 and string.match(line, "^%s*$") == nil then
-      table.insert(newlines, line)
+    if string.len(line) > 0 then
+      if is_windows() then
+        table.insert(newlines, line)
+      else
+        if string.match(line, "^%s*$") == nil then
+          table.insert(newlines, line)
+        end
+      end
     end
   end
   return newlines

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -94,7 +94,7 @@ end
 common.bracketed_paste_python = function(lines)
   local result = {}
   local is_ipython = contains(config.repl_definition.python.command, "ipython")
-  
+
   lines = remove_empty_lines(lines)
 
   local indent_open = false

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -22,10 +22,11 @@ end
 
 
 ---@param lines table
+--- Removes empty lines, which includes lines only with whitespaces
 local function remove_empty_lines(lines)
   local newlines = {}
   for _, line in pairs(lines) do
-    if string.len(line) > 0 then
+    if string.len(line) > 0 and string.match(line, "^%s*$") == nil then
       table.insert(newlines, line)
     end
   end

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -1,5 +1,5 @@
 local config = require("iron.config")
-local isWindows = require("iron.util.os").isWindows
+local is_windows = require("iron.util.os").is_windows
 local extend = require("iron.util.tables").extend
 local open_code = "\27[200~"
 local close_code = "\27[201~"
@@ -32,7 +32,7 @@ common.format = function(repldef, lines)
   end
 
   if #new > 0 then
-    if not isWindows() then
+    if not is_windows() then
       new[#new] = new[#new] .. cr
     end
   end
@@ -93,7 +93,7 @@ common.bracketed_paste_python = function(lines)
     if i < #lines then
       local isIpython = contains(config.repl_definition.python.command, "ipython")
 
-      if isWindows() and not isIpython or not isWindows() then
+      if is_windows() and not isIpython or not is_windows() then
         if i < #lines then
           if indent_open and string.match(lines[i + 1], "^%s") == nil then
             if not startsWithException(lines[i + 1]) then
@@ -107,7 +107,7 @@ common.bracketed_paste_python = function(lines)
     end
   end
 
-  if not isWindows() then
+  if not is_windows() then
     table.insert(result, cr)
   end
 

--- a/lua/iron/util/os.lua
+++ b/lua/iron/util/os.lua
@@ -1,6 +1,6 @@
 local checks = {}
 
-checks.isWindows = function()
+checks.is_windows = function()
     return package.config:sub(1,1) == '\\'
 end
 


### PR DESCRIPTION
refactored common.lua as well as removed all lines that have only white spaces in the remove_blank_lines function but only for unix.